### PR TITLE
hello-world: Raspberry Pi

### DIFF
--- a/recipes-example/hello-world/hello-world_0.5.bb
+++ b/recipes-example/hello-world/hello-world_0.5.bb
@@ -13,7 +13,7 @@ FILES:${PN} = "${bindir}/${NAME}"
 
 SYSTEM_NAME = "your_system"
 SYSTEM_NAME:qemuall = "QEMU"
-SYSTEM_NAME:rpi = "Raspberry"
+SYSTEM_NAME:rpi = "Raspberry Pi"
 
 do_compile () {
 	${CC} ${LDFLAGS} -DSYSTEM_NAME=\"${SYSTEM_NAME}\" -o ${NAME} main.c


### PR DESCRIPTION
Fix a typo and replace "Raspberry" with "Raspberry Pi" to avoid
confusion when running the app.

Signed-off-by: Leon Anavi <leon.anavi@konsulko.com>